### PR TITLE
fix: Makefile should follow proper conventions

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -1,8 +1,12 @@
-bs:
-	gcc -Wall -DBACKEND_LIBUSB -o bs bs.c -lusb-1.0
+CFLAGS += -Wall -DBACKEND_LIBUSB
 
-install:
+bs: bs.c
+	$(CC) $(CFLAGS) $(LDFLAGS) bs.c -lusb-1.0 -o bs
+
+install: bs
 	cp bs /usr/local/bin
 
 clean:
 	rm -f bs
+
+.PHONY: clean

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -1,12 +1,15 @@
+prefix = /usr/local
+bindir = $(prefix)/bin
+
 CFLAGS += -Wall -DBACKEND_LIBUSB
 
 bs: bs.c
 	$(CC) $(CFLAGS) $(LDFLAGS) bs.c -lusb-1.0 -o bs
 
 install: bs
-	cp bs /usr/local/bin
+	install -D bs "$(DESTDIR)$(bindir)"
 
 clean:
 	rm -f bs
 
-.PHONY: clean
+.PHONY: install clean


### PR DESCRIPTION
- Respect the user's CC, CFLAGS, and LDFLAGS variables for compilation.
- Make `install` respect the typical DESTDIR, prefix, and bindir variables.
- Set proper dependencies for the `install` target and mark `install` and `clean` as phony targets.

Also, I published an AUR package for the utility. To avoid naming conflicts with other packages, the package installs the utility under the name 'blaustahl'.

https://aur.archlinux.org/packages/blaustahl-git