### PR TITLE
Add Nix Flake Support and Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,40 @@ $ screen /dev/tty.usbmodem1234561
 
 Note: The default firmware on older devices isn't recognized by Windows, if that is the case please [update your firmware](#firmware) to [blaustahl_cdconly.uf2](firmware) in order to access Blaustahl from Windows. If you ordered Blaustahl recently the cdc\_only firmware will be installed by default and should be recognized by Windows.
 
+### Nix Flake Support
+
+For users who prefer Nix, a [Nix Flake](https://nixos.wiki/wiki/Flakes) is now available to simplify building and using Blaustahl's firmware and utility tools. This section offers an alternative method that does not replace the existing instructions for non-Nix environments.
+
+#### Prerequisites:
+- Install [Nix](https://nixos.org/download) and enable flake support by adding `experimental-features = nix-command flakes` to your Nix configuration.
+
+#### Building with the Flake:
+
+Instead of cloning the repository manually, you can reference the flake directly using its GitHub address.
+
+1. Use the flake to build the firmware, `bs` utility, or `srwp` tool:
+
+    - To build and obtain the firmware files:
+      ```bash
+      nix build github:machdyne/blaustahl#firmware
+      ```
+      The UF2 files will be placed in `result/lib/firmware/`.
+
+    - To build the `bs` utility:
+      ```bash
+      nix build github:machdyne/blaustahl#bs
+      ```
+      The binary will be available in the Nix store, with a symlink at `result/bin/bs`.
+
+    - To build the `srwp` tool:
+      ```bash
+      nix build github:machdyne/blaustahl#srwp
+      ```
+      Similarly, you'll find the resulting script or binary under `result/bin/srwp`.
+
+**Note:**
+- These steps are optional for those using Nix and do not affect the regular installation and usage instructions provided above for other environments.
+
 ## Using Blaustahl
 
 Blaustahl includes a built-in text editor with four 80x24 pages of text. The cursor can be moved with the arrow keys. When you'd like to enter or delete text, press CTRL-W to toggle the write mode.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "path": "/nix/store/l9nb64iii15y0nr37qrs1cfm6rlpg6gh-source",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "A very basic flake";
+
+  outputs = { self, nixpkgs }: let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+  in {
+
+    packages.x86_64-linux.firmware = let
+      pico-sdk-with-submodules = pkgs.pico-sdk.override {
+        withSubmodules = true;
+      };
+    in 
+    pkgs.stdenv.mkDerivation {
+      name = "blaustahl-firmware";
+      src = ./firmware/blaustahl;
+      nativeBuildInputs = with pkgs; [
+        cmake
+        gcc-arm-embedded
+        gnumake
+        picotool
+        python3
+      ];
+      buildInputs = [
+        pico-sdk-with-submodules
+      ];
+      PICO_SDK_PATH="${pico-sdk-with-submodules}/lib/pico-sdk";
+      cmakeFlags = [
+        "-DCMAKE_CXX_COMPILER=${pkgs.gcc-arm-embedded}/bin/arm-none-eabi-g++"
+        "-DCMAKE_C_COMPILER=${pkgs.gcc-arm-embedded}/bin/arm-none-eabi-gcc"
+        "-DCMAKE_MAKE_PROGRAM=${pkgs.gnumake}/bin/make"
+      ];
+      installPhase = ''
+        install -Dm444 blaustahl.uf2 $out/lib/firmware/blaustahl.uf2
+        install -Dm444 blaustahl_cdconly.uf2 $out/lib/firmware/blaustahl_cdconly.uf2
+      '';
+      dontFixup = true;
+    };
+
+    packages.x86_64-linux.bs = pkgs.stdenv.mkDerivation {
+      name = "bs";
+      src = ./sw;
+
+      makeFlags = [
+        "CFLAGS=-I${pkgs.libusb1.dev}/include"
+        "LDFLAGS=-L${pkgs.libusb1.out}/lib"
+        "bindir=/bin/bs"
+        "DESTDIR=$(out)"
+      ];
+    };
+
+    packages.x86_64-linux.srwp = pkgs.writers.writePython3Bin "srwp" {
+      libraries = [ pkgs.python3Packages.pyserial ];
+      doCheck = false;
+    } (builtins.readFile ./sw/srwp.py);
+
+    packages.x86_64-linux.default = self.packages.x86_64-linux.bs;
+
+  };
+}


### PR DESCRIPTION
**Description:**

This pull request adds a Nix Flake (`flake.nix`) to the project, enabling users to build the firmware and utilities (`bs` and `srwp`) directly from the repository using Nix. Additionally, a new section is added to the README to guide Nix users on how to use this feature.

**Changes:**

- **New `flake.nix`:**  
  - Provides Nix derivations for building the firmware, `bs`, and `srwp`.
  - Allows building these components with simple commands like:
    - `nix build github:machdyne/blaustahl#firmware`
    - `nix build github:machdyne/blaustahl#bs`
    - `nix build github:machdyne/blaustahl#srwp`
  
- **README Update:**  
  - A new **"Nix Flake Support"** section explains:
    - Required Nix setup and flake support.
    - How to build the firmware and tools using the flake.
    - Assurance that these instructions are optional and don't affect non-Nix usage.

**Benefits:**

- **For Nix Users:**  
  Simplifies building and using Blaustahl software with minimal setup.

- **For Non-Nix Users:**  
  Maintains existing instructions without disruption.
